### PR TITLE
chore: add docker image with necessary deps to work with wasm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Start from a slim Ubuntu image
+FROM ubuntu:latest
+
+# Update the package list and install clang, lld, python3, and build-essential
+RUN apt-get update && apt-get install -y \
+    clang \
+    lld \
+    python3 \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory
+WORKDIR /data
+
+# Command to keep the container running
+CMD ["/bin/bash"]
+

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ check:
 
 .PHONY: serve
 serve:
-	python3 -m http.server
+	python3 -m http.server 8080 --bind 0.0.0.0


### PR DESCRIPTION
Providing a Docker image.

build avec : `docker build -t wasm-intro .`
run : `docker run -v "$PWD":/data -it --rm -p 8080:8080 wasm-intro /bin/bash`